### PR TITLE
Fixed theming bug

### DIFF
--- a/app/src/main/java/com/aerosync/sample/HomeActivity.kt
+++ b/app/src/main/java/com/aerosync/sample/HomeActivity.kt
@@ -6,12 +6,12 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
 import com.aerosync.bank_link_sdk.EventListener
 import com.aerosync.bank_link_sdk.Widget
 
 
-class HomeActivity : AppCompatActivity(), EventListener {
+class HomeActivity : FragmentActivity(), EventListener {
 
     private val config = Widget(this, this);
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/bank-link-sdk/src/main/java/com/aerosync/bank_link_sdk/WidgetActivity.kt
+++ b/bank-link-sdk/src/main/java/com/aerosync/bank_link_sdk/WidgetActivity.kt
@@ -7,14 +7,14 @@ import android.view.KeyEvent
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
 import org.json.JSONObject
 
 
 
 
 
-class WidgetActivity: AppCompatActivity() {
+class WidgetActivity: FragmentActivity() {
 
     private lateinit var webView: WebView
     private lateinit var webAppInterface: WebAppInterface


### PR DESCRIPTION
One of our clients saw an issue when launching the Android SDK from their host App. The error was... 

`java.lang.RuntimeException: Unable to start activity ComponentInfo{com.stuzo.dab/com.aerosync.bank_link_sdk.WidgetActivity}: java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.`

This PR should fix that issue by switching the main landing Activities to a `FragmentActivity`.