### PR TITLE
fix: prevent crash when widget listener is missing after process death

### DIFF
--- a/bank-link-sdk/build.gradle
+++ b/bank-link-sdk/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 ext {
     PUBLISH_GROUP_ID = 'com.aerosync'
-    PUBLISH_VERSION = '1.5.0'
+    PUBLISH_VERSION = '1.5.1'
     PUBLISH_ARTIFACT_ID = 'bank-link-sdk'
 }
 

--- a/bank-link-sdk/src/main/java/com/aerosync/bank_link_sdk/Widget.kt
+++ b/bank-link-sdk/src/main/java/com/aerosync/bank_link_sdk/Widget.kt
@@ -18,7 +18,7 @@ data class Widget(
     ) {
 
     companion object {
-        lateinit var eventObj: EventListener
+        var eventObj: EventListener? = null
     }
 
     constructor(activity: Activity, eventListener: EventListener) : this(context = activity, eventListener = eventListener, environment = EnvironmentType.PROD) {
@@ -39,7 +39,7 @@ data class Widget(
             intent.putExtra("url", url)
             context.startActivity(intent);
         } catch (e: Exception) {
-            eventObj.onError("Error | $ERROR_WIDGET_LOAD | ${e.message}", context)
+            eventObj?.onError("Error | $ERROR_WIDGET_LOAD | ${e.message}", context)
         }
     }
 

--- a/bank-link-sdk/src/main/java/com/aerosync/bank_link_sdk/WidgetActivity.kt
+++ b/bank-link-sdk/src/main/java/com/aerosync/bank_link_sdk/WidgetActivity.kt
@@ -41,8 +41,15 @@ class WidgetActivity: FragmentActivity() {
         val intent = intent ?: return
         @Suppress("DEPRECATION")
         val url: String = intent.getSerializableExtra("url") as String;
+        val listener = Widget.eventObj
+        if (listener == null) {
+            // Recreated after a process kill with no listener registered.
+            // Close gracefully instead of crashing.
+            finish()
+            return
+        }
         webView = findViewById<WebView>(R.id.webView);
-        webAppInterface = WebAppInterface(this, Widget.eventObj);
+        webAppInterface = WebAppInterface(this, listener);
         @SuppressLint("SetJavaScriptEnabled")
         webView.settings.javaScriptEnabled = true;
         webView.addJavascriptInterface(webAppInterface, "BankLinkSDKAndroid");


### PR DESCRIPTION
## What
Fixes a crash where a lost event listener could take down the host app.

The widget's `EventListener` was stored in a static `lateinit` field (`Widget.eventObj`). On process death + task restore, Android recreates `WidgetActivity` without re-running the host's setup, so the field is uninitialized and `onCreate` throws `UninitializedPropertyAccessException`. 

## Ticket
[https://aeropay.clickup.com/t/10563802/868k5rn9v](https://aeropay.clickup.com/t/10563802/868k5rn9v)

## Change
- `Widget.eventObj`: `lateinit var` → nullable `var ... = null`
- `WidgetActivity`: if the listener is null on recreate, `finish()` gracefully instead of crashing
- `Widget.open()`: null-safe `eventObj?.onError(...)`

No API break; the field stays public, so host-side
`Application.onCreate` registration keeps working (and lets the widget resume rather than close).

## Testing
TC-OAUTH-001 — Happy path OAuth
TC-MFA-001 — Happy path MFA
TC-IAV-001 — Happy path IAV (Checking only, AliasWire)
TC-BANK-LINK-004 — Close button (X)
TC-BANK-LINK-005 — Back button (←)
