### PR TITLE
fix: enable DOM storage in WidgetActivity WebView

### DIFF
--- a/bank-link-sdk/build.gradle
+++ b/bank-link-sdk/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 ext {
     PUBLISH_GROUP_ID = 'com.aerosync'
-    PUBLISH_VERSION = '2.0.0'
+    PUBLISH_VERSION = '2.0.1'
     PUBLISH_ARTIFACT_ID = 'bank-link-sdk'
 }
 

--- a/bank-link-sdk/src/main/java/com/aerosync/bank_link_sdk/WidgetActivity.kt
+++ b/bank-link-sdk/src/main/java/com/aerosync/bank_link_sdk/WidgetActivity.kt
@@ -45,6 +45,8 @@ class WidgetActivity: FragmentActivity() {
         webAppInterface = WebAppInterface(this, Widget.eventObj);
         @SuppressLint("SetJavaScriptEnabled")
         webView.settings.javaScriptEnabled = true;
+        // Enable DOM storage (localStorage); required by the widget's auth flow.
+        webView.settings.domStorageEnabled = true;
         webView.addJavascriptInterface(webAppInterface, "BankLinkSDKAndroid");
         webView.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(


### PR DESCRIPTION
## Changes
Enable `domStorageEnabled` on the `WidgetActivity` WebView and bump the SDK artifact version to `2.0.1`.

## Testing
| Test Case ID    | Description                                                                           |
| --------------- | ------------------------------------------------------------------------------------- |
| TC-AEROPASS-001 | Happy path                                                                            |
| TC-AEROPASS-002 | Happy path                                                                            |
| TC-AEROPASS-003 | Happy path                                                                            |
| TC-AEROPASS-004 | Add a new bank – MFA                                                                  |
| TC-AEROPASS-005 | Add a new bank – MFA                                                                  |
| TC-AEROPASS-006 | Add a new bank – OAuth                                                                |
| TC-AEROPASS-007 | Add a new bank – OAuth                                                                |
| TC-AEROPASS-008 | Add a new bank – OAuth                                                                |
| TC-AEROPASS-009 | Unhappy path                                                                          |
| TC-AEROPASS-010 | No linked banks – Happy path                                                          |
| TC-AEROPASS-011 | Landing page after authentication                                                     |
| TC-AEROPASS-012 | Confirm Account page title and description (Returning users flow)                     |
| TC-AEROPASS-013 | Confirm Account page title and description (New bank link flow – Checking vs Savings) |
| TC-AEROPASS-014 | AeroStub (Mock OwnID)                                                                 |
